### PR TITLE
Reset `_stream_ready` after exception in `_make_connection`.

### DIFF
--- a/somfy_mylink_synergy/__init__.py
+++ b/somfy_mylink_synergy/__init__.py
@@ -88,7 +88,7 @@ class SomfyMyLinkSynergy:
             _LOGGER.error('Connection failed for %s on %s. '
                           'Please ensure device is reachable.',
                           self.host, self.port)
-            # Allow for subsequent request attempts in case the network
+            # Allow for subsequent connection attempts in case the network
             # condition changes.
             self._stream_ready.set()
             raise timeout_err

--- a/somfy_mylink_synergy/__init__.py
+++ b/somfy_mylink_synergy/__init__.py
@@ -88,6 +88,8 @@ class SomfyMyLinkSynergy:
             _LOGGER.error('Connection failed for %s on %s. '
                           'Please ensure device is reachable.',
                           self.host, self.port)
+            # Allow for subsequent request attempts in case the network
+            # condition changes.
             self._stream_ready.set()
             raise timeout_err
 

--- a/somfy_mylink_synergy/__init__.py
+++ b/somfy_mylink_synergy/__init__.py
@@ -88,6 +88,7 @@ class SomfyMyLinkSynergy:
             _LOGGER.error('Connection failed for %s on %s. '
                           'Please ensure device is reachable.',
                           self.host, self.port)
+            self._stream_ready.set()
             raise timeout_err
 
     async def _send_data(self, data):


### PR DESCRIPTION
Please consider this PR. I am experiencing this issue when running homeassistant. I'm not sure why my myLink is having intermittent connectivity issues (maybe I am exacerbating it with my automation frequency). This PR fixes HA losing control of the blinds once encountering an error (ie, subsequent attempts to control the blind can often succeed).